### PR TITLE
refactor: make file reads async

### DIFF
--- a/backend/src/handlers/document-management.js
+++ b/backend/src/handlers/document-management.js
@@ -138,7 +138,7 @@ export class DocumentManager {
             for (const metaFile of metaFiles) {
                 try {
                     const metaPath = path.join(this.documentsPath, metaFile);
-                    const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+                    const metadata = JSON.parse(await fs.promises.readFile(metaPath, 'utf8'));
                     documents.push(metadata);
                 } catch (error) {
                     console.warn(`Failed to read metadata for ${metaFile}:`, error);
@@ -170,7 +170,7 @@ export class DocumentManager {
                 throw new Error(`Document ${documentId} not found`);
             }
 
-            const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+            const metadata = JSON.parse(await fs.promises.readFile(metaPath, 'utf8'));
             
             // Try to read content file
             const possibleFiles = [
@@ -181,7 +181,7 @@ export class DocumentManager {
             let content = '';
             for (const file of possibleFiles) {
                 if (fs.existsSync(file)) {
-                    content = fs.readFileSync(file, 'utf8');
+                    content = await fs.promises.readFile(file, 'utf8');
                     break;
                 }
             }
@@ -272,7 +272,7 @@ export class DocumentManager {
             for (const fileName of files) {
                 try {
                     const filePath = path.join(importPath, fileName);
-                    const fileBuffer = fs.readFileSync(filePath);
+                    const fileBuffer = await fs.promises.readFile(filePath);
                     
                     const result = await this.addDocument(fileBuffer, fileName, documentType);
                     results.push(result);

--- a/backend/src/services/local-search.js
+++ b/backend/src/services/local-search.js
@@ -29,7 +29,7 @@ class LocalSearchService {
 
     async loadDocument(filePath, documentId) {
         try {
-            const content = fs.readFileSync(filePath, 'utf8');
+            const content = await fs.promises.readFile(filePath, 'utf8');
             const sections = this.parseMarkdownSections(content, documentId);
             
             this.documents.set(documentId, {


### PR DESCRIPTION
## Summary
- use fs.promises.readFile instead of readFileSync
- update document management to await async reads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "import LocalSearchService from './src/services/local-search.js'; const svc=new LocalSearchService(); const start=Date.now(); await svc.initialize(); console.log('init took', Date.now()-start, 'ms');"`

------
https://chatgpt.com/codex/tasks/task_e_68aa90c93588832c8f837552063b811e