### PR TITLE
feat: allow document removal from local search index

### DIFF
--- a/backend/src/handlers/document-management.js
+++ b/backend/src/handlers/document-management.js
@@ -112,8 +112,8 @@ export class DocumentManager {
                 throw new Error(`Document ${documentId} not found`);
             }
 
-            // Reinitialize search service to reflect changes
-            await localSearchService.initialize();
+            // Update search index to reflect removal
+            await localSearchService.removeDocument(documentId);
 
             return {
                 success: true,


### PR DESCRIPTION
## Summary
- add queued mutex in LocalSearchService to serialize index updates
- support removing documents from local search index
- call LocalSearchService.removeDocument from DocumentManager.removeDocument

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa93539428832cb96abf472ecc817d