### PR TITLE
refactor: centralize SSE helpers for local streaming

### DIFF
--- a/backend/src/utils/sse.js
+++ b/backend/src/utils/sse.js
@@ -1,0 +1,27 @@
+export function startStream(handler) {
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      await handler(controller, encoder);
+    }
+  });
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS'
+    }
+  });
+}
+
+export function sendEvent(controller, encoder, type, data) {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type, data })}\n\n`));
+}
+
+export function closeStream(controller) {
+  controller.close();
+}


### PR DESCRIPTION
## Summary
- add `startStream`, `sendEvent`, and `closeStream` helpers for server-sent events
- refactor local search streaming to use shared SSE utilities
- update OpenAI handler to reuse SSE helpers for local fallback streaming

## Testing
- `node -e "import('./src/utils/sse.js').then(()=>console.log('sse ok')).catch(e=>console.error(e))"`
- `node -e "import('./src/handlers/local-search.js').then(()=>console.log('local ok')).catch(e=>console.error(e))"`
- `node -e "import('./src/handlers/openai-search.js').then(()=>console.log('openai ok')).catch(e=>console.error(e))"`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa90b5c9a8832c9498e37be0e1aba9