### PR TITLE
feat: support document removal from local search

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "wrangler dev --port 8787",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "node --test"
   },
   "devDependencies": {
     "wrangler": "^4.32.0"

--- a/backend/src/handlers/document-management.js
+++ b/backend/src/handlers/document-management.js
@@ -112,8 +112,8 @@ export class DocumentManager {
                 throw new Error(`Document ${documentId} not found`);
             }
 
-            // Reinitialize search service to reflect changes
-            await localSearchService.initialize();
+            // Update search index
+            await localSearchService.removeDocument(documentId);
 
             return {
                 success: true,

--- a/backend/test/local-search.test.js
+++ b/backend/test/local-search.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import LocalSearchService from '../src/services/local-search.js';
+
+// Helper to create temporary markdown file
+function createTempDocument(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'local-search-'));
+  const file = path.join(dir, 'doc.md');
+  fs.writeFileSync(file, content);
+  return { file, dir };
+}
+
+test('add and remove document updates search index', async () => {
+  const service = new LocalSearchService();
+  service.initialized = true; // skip automatic initialization
+
+  const { file, dir } = createTempDocument('# Test Section\nThis is a test document.');
+  await service.addDocument(file, 'doc1');
+
+  let results = await service.search('test');
+  assert.equal(results.length > 0, true);
+
+  await service.removeDocument('doc1');
+  results = await service.search('test');
+  assert.equal(results.length, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- ensure LocalSearchService updates run sequentially with a simple mutex
- add removeDocument helper to drop documents from local index
- invoke LocalSearchService.removeDocument from DocumentManager when deleting files
- add Node test for add/remove document lifecycle

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa90c054bc832cacde7609c026100a