### PR TITLE
Secure token storage and backend auth hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# ArrowReg iOS and Backend
+
+This repository contains the ArrowReg iOS client and its Cloudflare Worker backend.
+
+## Highlights
+
+- **Secure token storage**: iOS client now stores authentication tokens in the Keychain and attaches them to outbound requests.
+- **Robust streaming**: Search streaming gracefully handles authorization errors and treats JSON and SSE responses uniformly.
+- **Production-ready backend**: CORS is restricted to configured origins and JWTs are verified using the [`jose`](https://github.com/panva/jose) library.
+
+## Development
+
+### Backend
+1. Install dependencies:
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Provide environment variables:
+   - `JWT_SECRET` – HMAC secret for token verification
+   - `ALLOWED_ORIGINS` – comma-separated list of allowed origins (defaults to `https://arrowreg.app`)
+3. Run the worker:
+   ```bash
+   npm run dev
+   ```
+
+### iOS
+The iOS app automatically reads any saved auth token from the Keychain. To set a token at runtime:
+```swift
+KeychainHelper.shared.save("<token>")
+```
+
+## Testing
+No automated test suite is bundled yet. Run `npm test` in the backend directory to verify future tests once added.
+
+## Update Plan
+- Fetch dependencies once network access is available to populate the `jose` package in `package-lock.json`.
+- Expand test coverage, including evaluation queries for search.
+- Implement local RAG pipeline and additional evaluation as described in project roadmap.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "itty-router": "^4.0.23",
         "marked": "^16.2.0",
-        "openai": "^4.58.2"
+        "openai": "^4.58.2",
+        "jose": "^5.2.0"
       },
       "devDependencies": {
         "wrangler": "^4.32.0"
@@ -1534,6 +1535,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.2.2.tgz",
       "integrity": "sha512-KegPW0l9SNPadProoFT07AB84uOqLUwzlXQ7HsqkS31WUrxkjdhcemRpTDUuetbMJ89uBtWeQSVoiEmUAu31uw==",
+      "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "",
+      "integrity": "",
       "license": "MIT"
     },
     "node_modules/kleur": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "itty-router": "^4.0.23",
     "marked": "^16.2.0",
-    "openai": "^4.58.2"
+    "openai": "^4.58.2",
+    "jose": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- store auth token in iOS Keychain and attach to search requests
- handle streaming auth errors and map HTTP codes in SearchService
- restrict backend CORS origins and verify JWTs with jose

## Testing
- `npm test` *(fails: Missing script "test")*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9c05e2fc832c9bab872e4d5b4c32