### PR TITLE
feat: restore swipe navigation with UIKit page view

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains the ArrowReg iOS application and its Cloudflare Worker 
 
 The backend now exposes shared Server-Sent Events (SSE) helpers in `src/utils/sse.js`.  These helpers simplify creating event streams, sending events, and closing the stream.  Handlers such as `handleLocalStreamSearch` and `handleStreamingSearch` use these helpers to deliver streaming search results consistently.
 
+## iOS Swipe Navigation
+
+The iOS client now uses a UIKit-backed `UIPageViewController` to render multi-turn conversations. This change restores reliable horizontal swipe gestures even when the page view is nested inside other SwiftUI scroll views.
+
 ## Development
 
 ```bash
@@ -16,6 +20,7 @@ npm run dev
 
 ## Update Plan
 
+- [x] Integrate UIKit-based page view to restore swipe gestures in conversation view.
 - [ ] Implement deterministic CFR chunking with precomputed embeddings.
 - [ ] Add hybrid cosine/BM25 search with top-k=8 results and strict citations.
 - [ ] Provide evaluation tests over 10 benchmark queries.

--- a/ios/ArrowReg/Core/Utilities/PageView.swift
+++ b/ios/ArrowReg/Core/Utilities/PageView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import UIKit
+
+/// A UIViewControllerRepresentable wrapper around UIPageViewController to provide
+/// reliable horizontal paging within SwiftUI contexts like nested ScrollViews.
+struct PageView<Page: View>: UIViewControllerRepresentable {
+    var pages: [Page]
+    @Binding var currentPage: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: Context) -> UIPageViewController {
+        let controller = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal)
+        controller.dataSource = context.coordinator
+        controller.delegate = context.coordinator
+
+        if let first = context.coordinator.controllers.first {
+            controller.setViewControllers([first], direction: .forward, animated: false)
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ controller: UIPageViewController, context: Context) {
+        let direction: UIPageViewController.NavigationDirection =
+            context.coordinator.currentIndex <= currentPage ? .forward : .reverse
+        context.coordinator.currentIndex = currentPage
+        controller.setViewControllers([context.coordinator.controllers[currentPage]], direction: direction, animated: true)
+    }
+
+    class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
+        var parent: PageView
+        var controllers: [UIViewController]
+        var currentIndex: Int
+
+        init(_ parent: PageView) {
+            self.parent = parent
+            self.controllers = parent.pages.map { UIHostingController(rootView: $0) }
+            self.currentIndex = parent.currentPage
+        }
+
+        func pageViewController(_ pageViewController: UIPageViewController,
+                                viewControllerBefore viewController: UIViewController) -> UIViewController? {
+            guard let index = controllers.firstIndex(of: viewController), index > 0 else { return nil }
+            return controllers[index - 1]
+        }
+
+        func pageViewController(_ pageViewController: UIPageViewController,
+                                viewControllerAfter viewController: UIViewController) -> UIViewController? {
+            guard let index = controllers.firstIndex(of: viewController), index + 1 < controllers.count else { return nil }
+            return controllers[index + 1]
+        }
+
+        func pageViewController(_ pageViewController: UIPageViewController,
+                                didFinishAnimating finished: Bool,
+                                previousViewControllers: [UIViewController],
+                                transitionCompleted completed: Bool) {
+            if completed, let visible = pageViewController.viewControllers?.first,
+               let index = controllers.firstIndex(of: visible) {
+                currentIndex = index
+                parent.currentPage = index
+            }
+        }
+    }
+}

--- a/ios/ArrowReg/Features/Search/Views/SearchView.swift
+++ b/ios/ArrowReg/Features/Search/Views/SearchView.swift
@@ -230,45 +230,20 @@ struct SearchView: View {
             }
             .padding(.bottom, 12)
             
-            // Conversation turns with TabView
-            TabView(selection: $selectedConversationTurn) {
-                ForEach(Array(viewModel.results.enumerated()), id: \.element.id) { index, result in
-                    VStack(spacing: 16) {
-                        // Turn indicator
-                        HStack {
-                            Text(index == 0 ? "Original Question" : "Follow-up \(index)")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(Color.gray.opacity(0.1))
-                                .cornerRadius(12)
-                            Spacer()
-                        }
-                        .padding(.horizontal)
-                        
-                        // Search result card
-                        SearchResultCard(result: result) {
-                            viewModel.bookmarkResult(result)
-                        }
-                        .padding(.horizontal)
-                        
-                        Spacer()
-                    }
-                    .padding(.top)
-                    .tag(index)
+            let pages = viewModel.results.enumerated().map { index, result in
+                ConversationPage(index: index, result: result) {
+                    viewModel.bookmarkResult(result)
                 }
             }
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .indexViewStyle(.page(backgroundDisplayMode: .never))
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .allowsHitTesting(true)
-            .onChange(of: selectedConversationTurn) { newValue in
-                print("🔄 Switched to conversation turn \(newValue + 1) of \(viewModel.results.count)")
-            }
-            .onAppear {
-                print("📱 TabView appeared with \(viewModel.results.count) results, current selection: \(selectedConversationTurn)")
-            }
+
+            PageView(pages: pages, currentPage: $selectedConversationTurn)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onChange(of: selectedConversationTurn) { newValue in
+                    print("🔄 Switched to conversation turn \(newValue + 1) of \(viewModel.results.count)")
+                }
+                .onAppear {
+                    print("📱 PageView appeared with \(viewModel.results.count) results, current selection: \(selectedConversationTurn)")
+                }
         }
     }
     
@@ -705,6 +680,36 @@ struct HistoryRow: View {
             onSelect()
         }
         .padding(.vertical, 4)
+    }
+}
+
+struct ConversationPage: View {
+    let index: Int
+    let result: SearchResult
+    let onBookmark: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Turn indicator
+            HStack {
+                Text(index == 0 ? "Original Question" : "Follow-up \(index)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(12)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            // Search result card
+            SearchResultCard(result: result, onBookmark: onBookmark)
+                .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding(.top)
     }
 }
 


### PR DESCRIPTION
## Summary
- replace SwiftUI TabView with UIKit-backed PageView for reliable horizontal swipes
- add ConversationPage view and PageView utility bridging UIPageViewController
- document new swipe navigation in README and update roadmap

## Testing
- `npm test` *(fails: AssertionError in tests/local-search.spec.js)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab869b8d0c832c81004544f2eec349